### PR TITLE
Changed logic to get driver numbers before 2014

### DIFF
--- a/f1pystats/driver_info.py
+++ b/f1pystats/driver_info.py
@@ -26,5 +26,5 @@ class DriverInfo:
                 driver_nums.append(i["permanentNumber"])
             else:
                 driver_nums.append(None)
-        
+
         return driver_nums

--- a/f1pystats/driver_info.py
+++ b/f1pystats/driver_info.py
@@ -20,4 +20,11 @@ class DriverInfo:
 
     def get_drivers_number(self):
         """Returns the list of driver's number"""
-        return [i["permanentNumber"] for i in self.info]
+        driver_nums = []
+        for i in self.info:
+            if "permanentNumber" in i:
+                driver_nums.append(i["permanentNumber"])
+            else:
+                driver_nums.append(None)
+        
+        return driver_nums

--- a/f1pystats/f1pystats.py
+++ b/f1pystats/f1pystats.py
@@ -33,10 +33,7 @@ def get_drivers(year: int, round_num: int = None):
     dr_name = dr_info.get_drivers_names()
     dr_dob = dr_info.get_drivers_dob()
     dr_nationality = dr_info.get_drivers_nationality()
-    if year >= 2014:
-        dr_perm_number = dr_info.get_drivers_number()
-    else:
-        dr_perm_number = [None] * len(dr_name)
+    dr_perm_number = dr_info.get_drivers_number()
 
     return pd.DataFrame(
         zip(dr_name, dr_perm_number, dr_nationality, dr_dob),


### PR DESCRIPTION
<!--
Thank you for contributing to F1PyStats!
Kindly fill out the following sections below to submit a pull request.
-->

## Description
<!-- Briefly describe the changes (additions/deletions) you have made to the code, and why-->
I have removed the conditional check which replaced all driver numbers with ```None``` before 2014. The code now checks if a driver has a number, despite the year.

## Related Issue(s)
<!-- Please note any issue numbers this pull request addresses/resolves (There should be at least one)-->
Fixes #54 by changing the logic used to get driver numbers <!--Replace X with this pull request's related issue number-->

## User-facing Changes
<!-- Describe any user-facing changes here. -->
Users can now view any permanent driver numbers before 2014.

## Screenshots (If necessary)
<!-- Include screenshots here, if you have made any visual changes to the application -->
![Screenshot from 2022-10-05 19-59-59](https://user-images.githubusercontent.com/52685467/194185077-4300043a-3c61-4e09-b54f-e97ab707c05b.png)
