### PR TITLE
Add a test for the permanentNumber omitted

### DIFF
--- a/tests/test_data/sample_drivers_info_2000.json
+++ b/tests/test_data/sample_drivers_info_2000.json
@@ -26,5 +26,15 @@
         "familyName": "Burti",
         "dateOfBirth": "1975-03-05",
         "nationality": "Brazilian"
+    },
+    {
+        "_comment1": "case: permanentNumber ommitted",
+        "driverId": "coulthard",
+        "code": "COU",
+        "url": "http:\/\/en.wikipedia.org\/wiki\/David_Coulthard",
+        "givenName": "David",
+        "familyName": "Coulthard",
+        "dateOfBirth": "1971-03-27",
+        "nationality": "British"
     }
 ]

--- a/tests/test_driver_info.py
+++ b/tests/test_driver_info.py
@@ -22,11 +22,17 @@ class TestDriverInfo:
 
     def test_drivers_dob(self):
         """Test for the get_drivers_dob method of DriverInfo"""
-        assert self.driver.get_drivers_dob() == ['1964-06-11', '1972-05-23', '1975-03-05', '1971-03-27']
+        assert self.driver.get_drivers_dob() == ['1964-06-11',
+                                                 '1972-05-23',
+                                                 '1975-03-05',
+                                                 '1971-03-27']
 
     def test_drivers_nationality(self):
         """Test for the get_drivers_nationality method of DriverInfo"""
-        assert self.driver.get_drivers_nationality() == ['French', 'Brazilian', 'Brazilian', 'British']
+        assert self.driver.get_drivers_nationality() == ['French',
+                                                         'Brazilian',
+                                                         'Brazilian',
+                                                         'British']
 
     def test_drivers_number(self):
         """Test for the get_drivers_number method of DriverInfo"""

--- a/tests/test_driver_info.py
+++ b/tests/test_driver_info.py
@@ -7,7 +7,7 @@ class TestDriverInfo:
     """Class containaing the functions for testing the DriverInfo class methods"""
 
     data = ""
-    with open("tests/test_data/first_3_drivers_info_2000.json", encoding="utf-8") as f:
+    with open("tests/test_data/sample_drivers_info_2000.json", encoding="utf-8") as f:
         data = json.load(f)
         f.close()
 
@@ -17,16 +17,17 @@ class TestDriverInfo:
         """Test for the get_drivers_names methods of DriverInfo"""
         assert self.driver.get_drivers_names() == ['Jean Alesi',
                                                    'Rubens Barrichello',
-                                                   'Luciano Burti']
+                                                   'Luciano Burti',
+                                                   'David Coulthard']
 
     def test_drivers_dob(self):
         """Test for the get_drivers_dob method of DriverInfo"""
-        assert self.driver.get_drivers_dob() == ['1964-06-11', '1972-05-23', '1975-03-05']
+        assert self.driver.get_drivers_dob() == ['1964-06-11', '1972-05-23', '1975-03-05', '1971-03-27']
 
     def test_drivers_nationality(self):
         """Test for the get_drivers_nationality method of DriverInfo"""
-        assert self.driver.get_drivers_nationality() == ['French', 'Brazilian', 'Brazilian']
+        assert self.driver.get_drivers_nationality() == ['French', 'Brazilian', 'Brazilian', 'British']
 
     def test_drivers_number(self):
         """Test for the get_drivers_number method of DriverInfo"""
-        assert self.driver.get_drivers_number() == ['23', '34', '45']
+        assert self.driver.get_drivers_number() == ['23', '34', '45', None]


### PR DESCRIPTION
## Description

- Add records with no permanentNumber to test data.
- Change name of the test data file from `first_3_drivers_info_2000.json` to `sample_drivers_info_2000.json`.
- Added support for function XXX to test data.

## Related Issue(s)
None
## User-facing Changes
None
## Screenshots (If necessary)
None