### PR TITLE
Adding get_constructors()

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ poetry add ../F1Pystats/dist/f1pystats-0.1.0.whl
 import F1PyStats as fp
 ```
 
-The package currently contains nine functions
+The package currently contains ten functions
 | Function                    	| Description                                                         	| Returned Datatype 	|
 |-----------------------------	|---------------------------------------------------------------------	|-------------------	|
 | fp.driver_standings(year)      	| Returns the driver standings for a particular year                  	| Pandas DataFrame  	|

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The package currently contains eight functions
 | fp.pit_stops(year, round, stop_number)           	| Returns the pit stop info for a specific race/pit stop 	                      | Pandas DataFrame  	|
 | fp.finishing_status(year,race_round)  | Returns the finishing status of races in a year (or a particular race if specified)     | Pandas DataFrame  |
 |fp.get_drivers(year, race_round) | Returns information on drivers in a given year (or a particular race if specified) | Pandas DataFrame |
-
+|fp.get_constructors(year) | Returns information on constructors in a given year | Pandas DataFrame |
 
 # Contributions
 NOTE: Please ensure you follow our [contributing guidelines](https://github.com/alec-kr/F1PyStats/blob/main/CONTRIBUTING.md) when contributing in any way to this repository.

--- a/f1pystats/__init__.py
+++ b/f1pystats/__init__.py
@@ -10,4 +10,5 @@ from .f1pystats import (driver_standings,
                         lap_times,
                         pit_stops,
                         get_drivers,
-                        finishing_status)
+                        finishing_status,
+                        get_constructors)

--- a/f1pystats/constructor_info.py
+++ b/f1pystats/constructor_info.py
@@ -1,0 +1,15 @@
+"""Contains all the functions used by get_constructors()"""
+
+
+class ConstructorInfo:
+    """This is the class which stores all the functions for get_constructors"""
+    def __init__(self, info):
+        self.info = info
+
+    def get_constructors_names(self):
+        """Returns the list of constructor names"""
+        return [i["name"] for i in self.info]
+
+    def get_constructors_nationality(self):
+        """Returns the list constructor nationalities"""
+        return [i["nationality"] for i in self.info]

--- a/f1pystats/f1pystats.py
+++ b/f1pystats/f1pystats.py
@@ -245,7 +245,7 @@ def get_constructors(year: int = None):
     """Returns a list of constructors for a specified year"""
 
     if year is None:
-        url = "https://ergast.com/api/f1/constructors?limit=230"
+        url = "https://ergast.com/api/f1/constructors.json?limit=230"
     else:
         url = f"http://ergast.com/api/f1/{year}/constructors.json"
 

--- a/f1pystats/f1pystats.py
+++ b/f1pystats/f1pystats.py
@@ -210,9 +210,15 @@ def finishing_status(year: int, race_round: int = 0):
         zip(status_id, status_info, status_count), columns=["StatusId", "Status", "Count"]
     )
 
-def get_constructors(year: int):
+def get_constructors(year: int = None):
     """Returns a list of constructors for a specified year"""
-    json_data = _get_json_content_from_url(f"https://ergast.com/api/f1/{year}/constructors.json")
+
+    if year is None:
+        url = "http://ergast.com/api/f1/constructors.json"
+    else:
+        url = f"http://ergast.com/api/f1/{year}/constructors.json"
+
+    json_data = _get_json_content_from_url(url)
 
     constructors_info = ConstructorInfo(json_data["MRData"]["ConstructorTable"]["Constructors"])
 

--- a/f1pystats/f1pystats.py
+++ b/f1pystats/f1pystats.py
@@ -18,6 +18,8 @@ from .finishing_status import FinishingStatus
 
 from .driver_info import DriverInfo
 
+from .constructor_info import ConstructorInfo
+
 
 def get_drivers(year: int, round_num: int = None):
     """Returns a list of drivers for a specified year"""
@@ -208,6 +210,19 @@ def finishing_status(year: int, race_round: int = 0):
         zip(status_id, status_info, status_count), columns=["StatusId", "Status", "Count"]
     )
 
+def get_constructors(year: int):
+    """Returns a list of constructors for a specified year"""
+    json_data = _get_json_content_from_url(f"https://ergast.com/api/f1/{year}/constructors.json")
+
+    constructors_info = ConstructorInfo(json_data["MRData"]["ConstructorTable"]["Constructors"])
+
+    constructors_names = constructors_info.get_constructors_names()
+    constructors_nationalities = constructors_info.get_constructors_nationality()
+
+    return pd.DataFrame(
+        zip(constructors_names, constructors_nationalities),
+        columns=["Constructor", "Nationality"],
+    )
 
 def _get_json_content_from_url(url, *args, timeout: int = 15, **kwargs):
     """Returns JSON content from requestsm URL"""

--- a/f1pystats/f1pystats.py
+++ b/f1pystats/f1pystats.py
@@ -245,7 +245,7 @@ def get_constructors(year: int = None):
     """Returns a list of constructors for a specified year"""
 
     if year is None:
-        url = "http://ergast.com/api/f1/constructors.json"
+        url = "https://ergast.com/api/f1/constructors?limit=230"
     else:
         url = f"http://ergast.com/api/f1/{year}/constructors.json"
 

--- a/tests/test_constructor_info.py
+++ b/tests/test_constructor_info.py
@@ -1,0 +1,29 @@
+"""This module is responsible for testing the methods in constructor_info.py"""
+
+import json
+from f1pystats.constructor_info import ConstructorInfo
+
+
+class TestConstructorInfo:
+    """Contains functions for testing the methods in ConstructorInfo"""
+
+    data = ""
+    with open("tests/test_data/sample_constructor_info_2010.json", encoding="utf-8") as f:
+        data = json.load(f)
+        f.close()
+
+    constructor = ConstructorInfo(data)
+
+    def test_constructors_names(self):
+        """Test for the get_constructors_names methods of ConstructorInfo"""
+        assert self.constructor.get_constructors_names() == ['Ferrari',
+                                                             'Force India',
+                                                             'HRT',
+                                                             'Lotus']
+
+    def test_constructors_nationalities(self):
+        """Test for the get_constructors_nationality method of ConstructorInfo"""
+        assert self.constructor.get_constructors_nationality() == ['Italian',
+                                                                   'Indian',
+                                                                   'Spanish',
+                                                                   'Malaysian']

--- a/tests/test_data/sample_constructor_info_2010.json
+++ b/tests/test_data/sample_constructor_info_2010.json
@@ -1,0 +1,26 @@
+[
+  {
+    "constructorId": "ferrari",
+    "url": "http:\/\/en.wikipedia.org\/wiki\/Scuderia_Ferrari",
+    "name": "Ferrari",
+    "nationality": "Italian"
+  },
+  {
+    "constructorId": "force_india",
+    "url": "http:\/\/en.wikipedia.org\/wiki\/Racing_Point_Force_India",
+    "name": "Force India",
+    "nationality": "Indian"
+  },
+  {
+    "constructorId": "hrt",
+    "url": "http:\/\/en.wikipedia.org\/wiki\/Hispania_Racing",
+    "name": "HRT",
+    "nationality": "Spanish"
+  },
+  {
+    "constructorId": "lotus_racing",
+    "url": "http:\/\/en.wikipedia.org\/wiki\/Lotus_Racing",
+    "name": "Lotus",
+    "nationality": "Malaysian"
+  }
+]


### PR DESCRIPTION
## Description
Implemented `get_constructors()` function, that takes year as an optional parameter, and returns a DataFrame of participating constructors in that year, and their nationality. If the year is not provided, return all constructors in F1 history.

## Related Issue(s)
Fixes https://github.com/alec-kr/F1PyStats/issues/40

## User-facing Changes
Users are now able to get a list of constructors by calling additional function from F1PyStats package.

## Screenshots (If necessary)
![image](https://user-images.githubusercontent.com/15880892/194393810-5882b4ef-005d-4ca5-9e3f-8ba69dd17b2a.png)
