### PR TITLE
Added handeling for the years between 1950 and 2022

### DIFF
--- a/f1pystats/f1pystats.py
+++ b/f1pystats/f1pystats.py
@@ -277,8 +277,8 @@ def get_constructors(year: int = None):
         url = "https://ergast.com/api/f1/constructors.json?limit=230"
     elif year < 1950 or year > 2022:
         raise ValueError("Only years between 1950 and 2022 are considered as valid value for year")
-
-    url = f"http://ergast.com/api/f1/{year}/constructors.json"
+    else:
+        url = f"http://ergast.com/api/f1/{year}/constructors.json"
 
     json_data = _get_json_content_from_url(url)
 

--- a/f1pystats/f1pystats.py
+++ b/f1pystats/f1pystats.py
@@ -29,13 +29,12 @@ def get_drivers(year: int, round_num: int = None):
     """Returns a list of drivers for a specified year"""
     if year < 1950 or year > 2022:
         raise ValueError("Only years between 1950 and 2022 are considered as valid value for year")
+    if round_num is None:
+        json_data = _get_json_content_from_url(f"https://ergast.com/api/f1/{year}/drivers.json")
     else:
-        if round_num is None:
-            json_data = _get_json_content_from_url(f"https://ergast.com/api/f1/{year}/drivers.json")
-        else:
-            json_data = _get_json_content_from_url(
-                f"https://ergast.com/api/f1/{year}/{round_num}/drivers.json"
-            )
+        json_data = _get_json_content_from_url(
+            f"https://ergast.com/api/f1/{year}/{round_num}/drivers.json"
+        )
 
         dr_info = DriverInfo(json_data["MRData"]["DriverTable"]["Drivers"])
 
@@ -54,222 +53,222 @@ def driver_standings(year: int):
     """Returns the driver standings for a specified year"""
     if year < 1950 or year > 2022:
         raise ValueError("Only years between 1950 and 2022 are considered as valid value for year")
-    else:
-        json_data = _get_json_content_from_url(f"https://ergast.com/api/f1/{year}/driverStandings.json")
-        standings_json = json_data["MRData"]["StandingsTable"]["StandingsLists"][0]["DriverStandings"]
-        d_res = DriverResults(standings_json)
-        positions = d_res.get_driver_positions()
-        names = d_res.get_driver_names()
-        teams = d_res.get_driver_teams()
-        nationalities = d_res.get_driver_nationality()
-        points = d_res.get_driver_points()
-        wins = d_res.get_driver_wins()
 
-        return pd.DataFrame(
-            zip(positions, names, nationalities, teams, points, wins),
-            columns=["POS", "Driver", "Nationality", "Constructor", "Points", "Wins"],
-        )
+    json_data = _get_json_content_from_url(f"https://ergast.com/api/f1/{year}/driverStandings.json")
+    standings_json = json_data["MRData"]["StandingsTable"]["StandingsLists"][0]["DriverStandings"]
+    d_res = DriverResults(standings_json)
+    positions = d_res.get_driver_positions()
+    names = d_res.get_driver_names()
+    teams = d_res.get_driver_teams()
+    nationalities = d_res.get_driver_nationality()
+    points = d_res.get_driver_points()
+    wins = d_res.get_driver_wins()
+
+    return pd.DataFrame(
+        zip(positions, names, nationalities, teams, points, wins),
+        columns=["POS", "Driver", "Nationality", "Constructor", "Points", "Wins"],
+    )
 
 
 def constructor_standings(year: int):
     """Returns the constructor standings for a specified year"""
     if year < 1950 or year > 2022:
         raise ValueError("Only years between 1950 and 2022 are considered as valid value for year")
-    else:
-        json_data = _get_json_content_from_url(
-            f"https://ergast.com/api/f1/{year}/constructorStandings.json"
-        )
-        standings_json = json_data["MRData"]["StandingsTable"]["StandingsLists"][0][
-            "ConstructorStandings"
-        ]
-        c_res = ConstructorResults(standings_json)
-        positions = c_res.get_constructor_positions()
-        teams = c_res.get_constructor_names()
-        nationality = c_res.get_constructor_nationality()
-        points = c_res.get_constructor_points()
-        wins = c_res.get_constructor_wins()
-    
-        return pd.DataFrame(
-            zip(positions, teams, nationality, points, wins),
-            columns=["POS", "Constructor", "Nationality", "Points", "Wins"],
-        )
+
+    json_data = _get_json_content_from_url(
+        f"https://ergast.com/api/f1/{year}/constructorStandings.json"
+    )
+    standings_json = json_data["MRData"]["StandingsTable"]["StandingsLists"][0][
+        "ConstructorStandings"
+    ]
+    c_res = ConstructorResults(standings_json)
+    positions = c_res.get_constructor_positions()
+    teams = c_res.get_constructor_names()
+    nationality = c_res.get_constructor_nationality()
+    points = c_res.get_constructor_points()
+    wins = c_res.get_constructor_wins()
+
+    return pd.DataFrame(
+        zip(positions, teams, nationality, points, wins),
+        columns=["POS", "Constructor", "Nationality", "Points", "Wins"],
+    )
 
 
 def race_winners(year: int):
     """Returns the race winners in a specified year"""
     if year < 1950 or year > 2022:
         raise ValueError("Only years between 1950 and 2022 are considered as valid value for year")
-    else:
-        json_data = _get_json_content_from_url(f"https://ergast.com/api/f1/{year}/results/1.json")
-        results_json = json_data["MRData"]["RaceTable"]["Races"]
-        r_winners = RaceWinners(results_json)
-        grands_prix = r_winners.get_grands_prix()
-        race_dates = r_winners.get_race_dates()
-        winners = r_winners.get_race_winners()
-        winning_constructors = r_winners.get_winning_constructors()
-        race_laps = r_winners.get_race_laps()
-        race_times = r_winners.get_race_times()
-        start_positions = r_winners.get_winner_start_positions()
-    
-        return pd.DataFrame(
-            zip(
-                grands_prix,
-                race_dates,
-                winners,
-                winning_constructors,
-                race_laps,
-                race_times,
-                start_positions,
-            ),
-            columns=["Grand Prix", "Date", "Winner", "Constructor", "Laps", "Race Time", "Grid"],
-        )
+
+    json_data = _get_json_content_from_url(f"https://ergast.com/api/f1/{year}/results/1.json")
+    results_json = json_data["MRData"]["RaceTable"]["Races"]
+    r_winners = RaceWinners(results_json)
+    grands_prix = r_winners.get_grands_prix()
+    race_dates = r_winners.get_race_dates()
+    winners = r_winners.get_race_winners()
+    winning_constructors = r_winners.get_winning_constructors()
+    race_laps = r_winners.get_race_laps()
+    race_times = r_winners.get_race_times()
+    start_positions = r_winners.get_winner_start_positions()
+
+    return pd.DataFrame(
+        zip(
+            grands_prix,
+            race_dates,
+            winners,
+            winning_constructors,
+            race_laps,
+            race_times,
+            start_positions,
+        ),
+        columns=["Grand Prix", "Date", "Winner", "Constructor", "Laps", "Race Time", "Grid"],
+    )
 
 
 def race_table(year: int):
     """Returns the race schedule for a specified year"""
     if year < 1950 or year > 2022:
         raise ValueError("Only years between 1950 and 2022 are considered as valid value for year")
-    else:
-        json_data = _get_json_content_from_url(f"https://ergast.com/api/f1/{year}.json")
-        schedule_json = json_data["MRData"]["RaceTable"]["Races"]
-        r_sched = RaceSchedule(schedule_json)
-        race_round = r_sched.get_race_round()
-        race_name = r_sched.get_race_names()
-        race_circuits = r_sched.get_race_circuits()
-        race_schedule_date = r_sched.get_race_schedule_dates()
-        race_schedule_time = r_sched.get_race_schedule_times()
-        race_locality = r_sched.get_race_locality()
-        race_country = r_sched.get_race_countries()
-    
-        return pd.DataFrame(
-            zip(
-                race_round,
-                race_name,
-                race_circuits,
-                race_schedule_date,
-                race_schedule_time,
-                race_locality,
-                race_country,
-            ),
-            columns=[
-                "Round",
-                "Race Name",
-                "Circuit",
-                "Date",
-                "Time",
-                "Locality",
-                "Country",
-            ],
-        )
+
+    json_data = _get_json_content_from_url(f"https://ergast.com/api/f1/{year}.json")
+    schedule_json = json_data["MRData"]["RaceTable"]["Races"]
+    r_sched = RaceSchedule(schedule_json)
+    race_round = r_sched.get_race_round()
+    race_name = r_sched.get_race_names()
+    race_circuits = r_sched.get_race_circuits()
+    race_schedule_date = r_sched.get_race_schedule_dates()
+    race_schedule_time = r_sched.get_race_schedule_times()
+    race_locality = r_sched.get_race_locality()
+    race_country = r_sched.get_race_countries()
+
+    return pd.DataFrame(
+        zip(
+            race_round,
+            race_name,
+            race_circuits,
+            race_schedule_date,
+            race_schedule_time,
+            race_locality,
+            race_country,
+        ),
+        columns=[
+            "Round",
+            "Race Name",
+            "Circuit",
+            "Date",
+            "Time",
+            "Locality",
+            "Country",
+        ],
+    )
 
 
 def lap_times(year: int, race_round: int, lap_number: int):
     """Returns the lap times for a specified year, race round and lap number"""
     if year < 1950 or year > 2022:
         raise ValueError("Only years between 1950 and 2022 are considered as valid value for year")
-    else:
-        json_data = _get_json_content_from_url(
-            f"https://ergast.com/api/f1/{year}/{race_round}/laps/{lap_number}.json"
-        )
-        schedule_json = json_data["MRData"]["RaceTable"]["Races"][0]["Laps"][0]["Timings"]
-        l_times = LapTimes(schedule_json)
-        driver_names = l_times.get_driver_names()
-        driver_positions = l_times.get_driver_positions()
-        driver_timings = l_times.get_lap_time()
-    
-        return pd.DataFrame(
-            zip(
-                driver_positions,
-                driver_names,
-                driver_timings,
-            ),
-            columns=[
-                "POS",
-                "Driver",
-                "Lap Time",
-            ],
-        )
+
+    json_data = _get_json_content_from_url(
+        f"https://ergast.com/api/f1/{year}/{race_round}/laps/{lap_number}.json"
+    )
+    schedule_json = json_data["MRData"]["RaceTable"]["Races"][0]["Laps"][0]["Timings"]
+    l_times = LapTimes(schedule_json)
+    driver_names = l_times.get_driver_names()
+    driver_positions = l_times.get_driver_positions()
+    driver_timings = l_times.get_lap_time()
+
+    return pd.DataFrame(
+        zip(
+            driver_positions,
+            driver_names,
+            driver_timings,
+        ),
+        columns=[
+            "POS",
+            "Driver",
+            "Lap Time",
+        ],
+    )
 
 
 def pit_stops(year: int, race_round: int, stop_number: int = 0):
     """Returns the pit stops for a specific race in a season"""
     if year < 2012 or year > 2022:
         raise ValueError("Only years between 2012 and 2022 are considered as valid value for year")
-    else:
-        if int == 0:
-            json_data = _get_json_content_from_url(
-                f"https://ergast.com/api/f1/{year}/{race_round}/pitstops.json"
-            )
-        else:
-            json_data = _get_json_content_from_url(
-                f"https://ergast.com/api/f1/{year}/{race_round}/pitstops/{stop_number}.json"
-            )
-        stops_json = json_data["MRData"]["RaceTable"]["Races"][0]["PitStops"]
-        p_stops = PitStops(stops_json)
-        driver_names = p_stops.get_driver_names()
-        stop_number = p_stops.get_stop_numbers()
-        lap_number = p_stops.get_lap_numbers()
-        race_time = p_stops.get_times()
-        stop_duration = p_stops.get_durations()
 
-        return pd.DataFrame(
-            zip(driver_names, stop_number, lap_number, race_time, stop_duration),
-            columns=["Driver", "Stop", "Lap", "Time", "Duration"],
+    if int == 0:
+        json_data = _get_json_content_from_url(
+            f"https://ergast.com/api/f1/{year}/{race_round}/pitstops.json"
         )
+    else:
+        json_data = _get_json_content_from_url(
+            f"https://ergast.com/api/f1/{year}/{race_round}/pitstops/{stop_number}.json"
+        )
+    stops_json = json_data["MRData"]["RaceTable"]["Races"][0]["PitStops"]
+    p_stops = PitStops(stops_json)
+    driver_names = p_stops.get_driver_names()
+    stop_number = p_stops.get_stop_numbers()
+    lap_number = p_stops.get_lap_numbers()
+    race_time = p_stops.get_times()
+    stop_duration = p_stops.get_durations()
+
+    return pd.DataFrame(
+        zip(driver_names, stop_number, lap_number, race_time, stop_duration),
+        columns=["Driver", "Stop", "Lap", "Time", "Duration"],
+    )
 
 
 def finishing_status(year: int, race_round: int = 0):
     """Returns the finishing status for a year with a optional parameter of round"""
     if year < 1950 or year > 2022:
         raise ValueError("Only years between 1950 and 2022 are considered as valid value for year")
+
+    if race_round == 0:
+        json_data = _get_json_content_from_url(f"https://ergast.com/api/f1/{year}/status.json")
     else:
-        if race_round == 0:
-            json_data = _get_json_content_from_url(f"https://ergast.com/api/f1/{year}/status.json")
-        else:
-            json_data = _get_json_content_from_url(
-                f"https://ergast.com/api/f1/{year}/{race_round}/status.json"
-            )
-        f_status = FinishingStatus(json_data["MRData"]["StatusTable"]["Status"])
-        status_id = f_status.get_status_id()
-        status_info = f_status.get_status()
-        status_count = f_status.get_status_count()
-    
-        return pd.DataFrame(
-            zip(status_id, status_info, status_count), columns=["StatusId", "Status", "Count"]
+        json_data = _get_json_content_from_url(
+            f"https://ergast.com/api/f1/{year}/{race_round}/status.json"
         )
+    f_status = FinishingStatus(json_data["MRData"]["StatusTable"]["Status"])
+    status_id = f_status.get_status_id()
+    status_info = f_status.get_status()
+    status_count = f_status.get_status_count()
+
+    return pd.DataFrame(
+        zip(status_id, status_info, status_count), columns=["StatusId", "Status", "Count"]
+    )
 
 
 def sprint_results(year: int, race_round: int):
     """Returns the sprint qualifying results for a year and round"""
     if year < 1950 or year > 2022:
         raise ValueError("Only years between 1950 and 2022 are considered as valid value for year")
-    else:
-        json_data = _get_json_content_from_url(
-            f"http://ergast.com/api/f1/{year}/{race_round}/sprint.json"
-        )
-        if len(json_data["MRData"]["RaceTable"]["Races"]) == 0 :
-            raise ValueError("No Sprint Race found for this Grand Prix")
-        s_results = SprintResults(json_data["MRData"]["RaceTable"]["Races"][0]["SprintResults"])
-        driver_pos = s_results.get_driver_pos()
-        driver_name = s_results.get_driver_name()
-        driver_team = s_results.get_driver_team()
-        driver_status = s_results.get_driver_status()
-        driver_number = s_results.get_driver_number()
-        driver_laps = s_results.get_laps()
-        driver_grid = s_results.get_driver_grid()
-        driver_time = s_results.get_driver_time()
-        driver_points = s_results.get_driver_points()
-    
-        return pd.DataFrame(
-            zip(
-                driver_pos, driver_name, driver_number, driver_team, driver_laps, driver_grid,
-                driver_status, driver_time, driver_points
-            ),
-            columns=[
-                "Position", "Name", "Driver Number", "Constructor", "Laps", "Grid",
-                "Status", "Time", "Points"
-            ]
-        )
+
+    json_data = _get_json_content_from_url(
+        f"http://ergast.com/api/f1/{year}/{race_round}/sprint.json"
+    )
+    if len(json_data["MRData"]["RaceTable"]["Races"]) == 0 :
+        raise ValueError("No Sprint Race found for this Grand Prix")
+    s_results = SprintResults(json_data["MRData"]["RaceTable"]["Races"][0]["SprintResults"])
+    driver_pos = s_results.get_driver_pos()
+    driver_name = s_results.get_driver_name()
+    driver_team = s_results.get_driver_team()
+    driver_status = s_results.get_driver_status()
+    driver_number = s_results.get_driver_number()
+    driver_laps = s_results.get_laps()
+    driver_grid = s_results.get_driver_grid()
+    driver_time = s_results.get_driver_time()
+    driver_points = s_results.get_driver_points()
+
+    return pd.DataFrame(
+        zip(
+            driver_pos, driver_name, driver_number, driver_team, driver_laps, driver_grid,
+            driver_status, driver_time, driver_points
+        ),
+        columns=[
+            "Position", "Name", "Driver Number", "Constructor", "Laps", "Grid",
+            "Status", "Time", "Points"
+        ]
+    )
 
 
 def get_constructors(year: int = None):
@@ -278,8 +277,8 @@ def get_constructors(year: int = None):
         url = "https://ergast.com/api/f1/constructors.json?limit=230"
     elif year < 1950 or year > 2022:
         raise ValueError("Only years between 1950 and 2022 are considered as valid value for year")
-    else:
-        url = f"http://ergast.com/api/f1/{year}/constructors.json"
+
+    url = f"http://ergast.com/api/f1/{year}/constructors.json"
 
     json_data = _get_json_content_from_url(url)
 
@@ -298,39 +297,39 @@ def qualifying_results(year: int, race_round: int):
     """Returns the driver name , driver position, driver number, constructor name , the 3 Q times"""
     if year < 1950 or year > 2022:
         raise ValueError("Only years between 1950 and 2022 are considered as valid value for year")
-    else:
-        json_data = _get_json_content_from_url(
-            f"https://ergast.com/api/f1/{year}/{race_round}/qualifying.json"
-        )
-        schedule_json = json_data["MRData"]["RaceTable"]["Races"][0]["QualifyingResults"]
-        r_obj= QualifyingResults(schedule_json)
-        driver_positions=r_obj.get_positions()
-        driver_names=r_obj.get_names()
-        driver_numbers=r_obj.get_driver_numbers()
-        constructor_names=r_obj.get_constructors()
-        q1_times=r_obj.get_q1_times()
-        q2_times=r_obj.get_q2_times()
-        q3_times=r_obj.get_q3_times()
-        return pd.DataFrame(
-            zip(
-                driver_positions,
-                driver_names,
-                driver_numbers,
-                constructor_names,
-                q1_times,
-                q2_times,
-                q3_times
-            ),
-            columns=[
-                "Position",
-                "DriverName",
-                "DriverNumber",
-                "Constructor",
-                "Q1",
-                "Q2",
-                "Q3"
-            ],
-        )
+
+    json_data = _get_json_content_from_url(
+        f"https://ergast.com/api/f1/{year}/{race_round}/qualifying.json"
+    )
+    schedule_json = json_data["MRData"]["RaceTable"]["Races"][0]["QualifyingResults"]
+    r_obj= QualifyingResults(schedule_json)
+    driver_positions=r_obj.get_positions()
+    driver_names=r_obj.get_names()
+    driver_numbers=r_obj.get_driver_numbers()
+    constructor_names=r_obj.get_constructors()
+    q1_times=r_obj.get_q1_times()
+    q2_times=r_obj.get_q2_times()
+    q3_times=r_obj.get_q3_times()
+    return pd.DataFrame(
+        zip(
+            driver_positions,
+            driver_names,
+            driver_numbers,
+            constructor_names,
+            q1_times,
+            q2_times,
+            q3_times
+        ),
+        columns=[
+            "Position",
+            "DriverName",
+            "DriverNumber",
+            "Constructor",
+            "Q1",
+            "Q2",
+            "Q3"
+        ],
+    )
 
 def get_circuits(year:int=None):
     """Returns the circuit name, circuit locality and circuit country"""
@@ -338,8 +337,8 @@ def get_circuits(year:int=None):
         json_data = _get_json_content_from_url("http://ergast.com/api/f1/circuits.json?limit=76")
     elif year < 1950 or year > 2022:
         raise ValueError("Only years between 1950 and 2022 are considered as valid value for year")
-    else:
-        json_data = _get_json_content_from_url(f"https://ergast.com/api/f1/{year}/circuits.json")
+
+    json_data = _get_json_content_from_url(f"https://ergast.com/api/f1/{year}/circuits.json")
     schedule_json = json_data["MRData"]["CircuitTable"]["Circuits"]
     rr_obj=RaceCircuits(schedule_json)
     circuit_name=rr_obj.get_circuit_name()

--- a/f1pystats/f1pystats.py
+++ b/f1pystats/f1pystats.py
@@ -36,17 +36,17 @@ def get_drivers(year: int, round_num: int = None):
             f"https://ergast.com/api/f1/{year}/{round_num}/drivers.json"
         )
 
-        dr_info = DriverInfo(json_data["MRData"]["DriverTable"]["Drivers"])
+    dr_info = DriverInfo(json_data["MRData"]["DriverTable"]["Drivers"])
 
-        dr_name = dr_info.get_drivers_names()
-        dr_dob = dr_info.get_drivers_dob()
-        dr_nationality = dr_info.get_drivers_nationality()
-        dr_perm_number = dr_info.get_drivers_number()
+    dr_name = dr_info.get_drivers_names()
+    dr_dob = dr_info.get_drivers_dob()
+    dr_nationality = dr_info.get_drivers_nationality()
+    dr_perm_number = dr_info.get_drivers_number()
 
-        return pd.DataFrame(
-            zip(dr_name, dr_perm_number, dr_nationality, dr_dob),
-            columns=["Drivers", "Permanent Number", "Nationality", "Date of Birth"],
-        )
+    return pd.DataFrame(
+        zip(dr_name, dr_perm_number, dr_nationality, dr_dob),
+        columns=["Drivers", "Permanent Number", "Nationality", "Date of Birth"],
+    )
 
 
 def driver_standings(year: int):

--- a/f1pystats/f1pystats.py
+++ b/f1pystats/f1pystats.py
@@ -339,7 +339,7 @@ def get_circuits(year:int=None):
         raise ValueError("Only years between 1950 and 2022 are considered as valid value for year")
     else:
         json_data = _get_json_content_from_url(f"https://ergast.com/api/f1/{year}/circuits.json")
-    
+
     schedule_json = json_data["MRData"]["CircuitTable"]["Circuits"]
     rr_obj=RaceCircuits(schedule_json)
     circuit_name=rr_obj.get_circuit_name()

--- a/f1pystats/f1pystats.py
+++ b/f1pystats/f1pystats.py
@@ -27,228 +27,257 @@ from .constructor_info import ConstructorInfo
 
 def get_drivers(year: int, round_num: int = None):
     """Returns a list of drivers for a specified year"""
-    if round_num is None:
-        json_data = _get_json_content_from_url(f"https://ergast.com/api/f1/{year}/drivers.json")
+    if year < 1950 and year > 2022:
+        raise ValueError("Only years between 1950 and 2022 are considered as valid value for year")
     else:
-        json_data = _get_json_content_from_url(
-            f"https://ergast.com/api/f1/{year}/{round_num}/drivers.json"
+        if round_num is None:
+            json_data = _get_json_content_from_url(f"https://ergast.com/api/f1/{year}/drivers.json")
+        else:
+            json_data = _get_json_content_from_url(
+                f"https://ergast.com/api/f1/{year}/{round_num}/drivers.json"
+            )
+
+        dr_info = DriverInfo(json_data["MRData"]["DriverTable"]["Drivers"])
+
+        dr_name = dr_info.get_drivers_names()
+        dr_dob = dr_info.get_drivers_dob()
+        dr_nationality = dr_info.get_drivers_nationality()
+        dr_perm_number = dr_info.get_drivers_number()
+
+        return pd.DataFrame(
+            zip(dr_name, dr_perm_number, dr_nationality, dr_dob),
+            columns=["Drivers", "Permanent Number", "Nationality", "Date of Birth"],
         )
-
-    dr_info = DriverInfo(json_data["MRData"]["DriverTable"]["Drivers"])
-
-    dr_name = dr_info.get_drivers_names()
-    dr_dob = dr_info.get_drivers_dob()
-    dr_nationality = dr_info.get_drivers_nationality()
-    dr_perm_number = dr_info.get_drivers_number()
-
-    return pd.DataFrame(
-        zip(dr_name, dr_perm_number, dr_nationality, dr_dob),
-        columns=["Drivers", "Permanent Number", "Nationality", "Date of Birth"],
-    )
 
 
 def driver_standings(year: int):
     """Returns the driver standings for a specified year"""
-    json_data = _get_json_content_from_url(f"https://ergast.com/api/f1/{year}/driverStandings.json")
-    standings_json = json_data["MRData"]["StandingsTable"]["StandingsLists"][0]["DriverStandings"]
-    d_res = DriverResults(standings_json)
-    positions = d_res.get_driver_positions()
-    names = d_res.get_driver_names()
-    teams = d_res.get_driver_teams()
-    nationalities = d_res.get_driver_nationality()
-    points = d_res.get_driver_points()
-    wins = d_res.get_driver_wins()
+    if year < 1950 and year > 2022:
+        raise ValueError("Only years between 1950 and 2022 are considered as valid value for year")
+    else:
+        json_data = _get_json_content_from_url(f"https://ergast.com/api/f1/{year}/driverStandings.json")
+        standings_json = json_data["MRData"]["StandingsTable"]["StandingsLists"][0]["DriverStandings"]
+        d_res = DriverResults(standings_json)
+        positions = d_res.get_driver_positions()
+        names = d_res.get_driver_names()
+        teams = d_res.get_driver_teams()
+        nationalities = d_res.get_driver_nationality()
+        points = d_res.get_driver_points()
+        wins = d_res.get_driver_wins()
 
-    return pd.DataFrame(
-        zip(positions, names, nationalities, teams, points, wins),
-        columns=["POS", "Driver", "Nationality", "Constructor", "Points", "Wins"],
-    )
+        return pd.DataFrame(
+            zip(positions, names, nationalities, teams, points, wins),
+            columns=["POS", "Driver", "Nationality", "Constructor", "Points", "Wins"],
+        )
 
 
 def constructor_standings(year: int):
     """Returns the constructor standings for a specified year"""
-    json_data = _get_json_content_from_url(
-        f"https://ergast.com/api/f1/{year}/constructorStandings.json"
-    )
-    standings_json = json_data["MRData"]["StandingsTable"]["StandingsLists"][0][
-        "ConstructorStandings"
-    ]
-    c_res = ConstructorResults(standings_json)
-    positions = c_res.get_constructor_positions()
-    teams = c_res.get_constructor_names()
-    nationality = c_res.get_constructor_nationality()
-    points = c_res.get_constructor_points()
-    wins = c_res.get_constructor_wins()
-
-    return pd.DataFrame(
-        zip(positions, teams, nationality, points, wins),
-        columns=["POS", "Constructor", "Nationality", "Points", "Wins"],
-    )
+    if year < 1950 and year > 2022:
+        raise ValueError("Only years between 1950 and 2022 are considered as valid value for year")
+    else:
+        json_data = _get_json_content_from_url(
+            f"https://ergast.com/api/f1/{year}/constructorStandings.json"
+        )
+        standings_json = json_data["MRData"]["StandingsTable"]["StandingsLists"][0][
+            "ConstructorStandings"
+        ]
+        c_res = ConstructorResults(standings_json)
+        positions = c_res.get_constructor_positions()
+        teams = c_res.get_constructor_names()
+        nationality = c_res.get_constructor_nationality()
+        points = c_res.get_constructor_points()
+        wins = c_res.get_constructor_wins()
+    
+        return pd.DataFrame(
+            zip(positions, teams, nationality, points, wins),
+            columns=["POS", "Constructor", "Nationality", "Points", "Wins"],
+        )
 
 
 def race_winners(year: int):
     """Returns the race winners in a specified year"""
-    json_data = _get_json_content_from_url(f"https://ergast.com/api/f1/{year}/results/1.json")
-    results_json = json_data["MRData"]["RaceTable"]["Races"]
-    r_winners = RaceWinners(results_json)
-    grands_prix = r_winners.get_grands_prix()
-    race_dates = r_winners.get_race_dates()
-    winners = r_winners.get_race_winners()
-    winning_constructors = r_winners.get_winning_constructors()
-    race_laps = r_winners.get_race_laps()
-    race_times = r_winners.get_race_times()
-    start_positions = r_winners.get_winner_start_positions()
-
-    return pd.DataFrame(
-        zip(
-            grands_prix,
-            race_dates,
-            winners,
-            winning_constructors,
-            race_laps,
-            race_times,
-            start_positions,
-        ),
-        columns=["Grand Prix", "Date", "Winner", "Constructor", "Laps", "Race Time", "Grid"],
-    )
+    if year < 1950 and year > 2022:
+        raise ValueError("Only years between 1950 and 2022 are considered as valid value for year")
+    else:
+        json_data = _get_json_content_from_url(f"https://ergast.com/api/f1/{year}/results/1.json")
+        results_json = json_data["MRData"]["RaceTable"]["Races"]
+        r_winners = RaceWinners(results_json)
+        grands_prix = r_winners.get_grands_prix()
+        race_dates = r_winners.get_race_dates()
+        winners = r_winners.get_race_winners()
+        winning_constructors = r_winners.get_winning_constructors()
+        race_laps = r_winners.get_race_laps()
+        race_times = r_winners.get_race_times()
+        start_positions = r_winners.get_winner_start_positions()
+    
+        return pd.DataFrame(
+            zip(
+                grands_prix,
+                race_dates,
+                winners,
+                winning_constructors,
+                race_laps,
+                race_times,
+                start_positions,
+            ),
+            columns=["Grand Prix", "Date", "Winner", "Constructor", "Laps", "Race Time", "Grid"],
+        )
 
 
 def race_table(year: int):
     """Returns the race schedule for a specified year"""
-    json_data = _get_json_content_from_url(f"https://ergast.com/api/f1/{year}.json")
-    schedule_json = json_data["MRData"]["RaceTable"]["Races"]
-    r_sched = RaceSchedule(schedule_json)
-    race_round = r_sched.get_race_round()
-    race_name = r_sched.get_race_names()
-    race_circuits = r_sched.get_race_circuits()
-    race_schedule_date = r_sched.get_race_schedule_dates()
-    race_schedule_time = r_sched.get_race_schedule_times()
-    race_locality = r_sched.get_race_locality()
-    race_country = r_sched.get_race_countries()
-
-    return pd.DataFrame(
-        zip(
-            race_round,
-            race_name,
-            race_circuits,
-            race_schedule_date,
-            race_schedule_time,
-            race_locality,
-            race_country,
-        ),
-        columns=[
-            "Round",
-            "Race Name",
-            "Circuit",
-            "Date",
-            "Time",
-            "Locality",
-            "Country",
-        ],
-    )
+    if year < 1950 and year > 2022:
+        raise ValueError("Only years between 1950 and 2022 are considered as valid value for year")
+    else:
+        json_data = _get_json_content_from_url(f"https://ergast.com/api/f1/{year}.json")
+        schedule_json = json_data["MRData"]["RaceTable"]["Races"]
+        r_sched = RaceSchedule(schedule_json)
+        race_round = r_sched.get_race_round()
+        race_name = r_sched.get_race_names()
+        race_circuits = r_sched.get_race_circuits()
+        race_schedule_date = r_sched.get_race_schedule_dates()
+        race_schedule_time = r_sched.get_race_schedule_times()
+        race_locality = r_sched.get_race_locality()
+        race_country = r_sched.get_race_countries()
+    
+        return pd.DataFrame(
+            zip(
+                race_round,
+                race_name,
+                race_circuits,
+                race_schedule_date,
+                race_schedule_time,
+                race_locality,
+                race_country,
+            ),
+            columns=[
+                "Round",
+                "Race Name",
+                "Circuit",
+                "Date",
+                "Time",
+                "Locality",
+                "Country",
+            ],
+        )
 
 
 def lap_times(year: int, race_round: int, lap_number: int):
     """Returns the lap times for a specified year, race round and lap number"""
-    json_data = _get_json_content_from_url(
-        f"https://ergast.com/api/f1/{year}/{race_round}/laps/{lap_number}.json"
-    )
-    schedule_json = json_data["MRData"]["RaceTable"]["Races"][0]["Laps"][0]["Timings"]
-    l_times = LapTimes(schedule_json)
-    driver_names = l_times.get_driver_names()
-    driver_positions = l_times.get_driver_positions()
-    driver_timings = l_times.get_lap_time()
-
-    return pd.DataFrame(
-        zip(
-            driver_positions,
-            driver_names,
-            driver_timings,
-        ),
-        columns=[
-            "POS",
-            "Driver",
-            "Lap Time",
-        ],
-    )
+    if year < 1950 and year > 2022:
+        raise ValueError("Only years between 1950 and 2022 are considered as valid value for year")
+    else:
+        json_data = _get_json_content_from_url(
+            f"https://ergast.com/api/f1/{year}/{race_round}/laps/{lap_number}.json"
+        )
+        schedule_json = json_data["MRData"]["RaceTable"]["Races"][0]["Laps"][0]["Timings"]
+        l_times = LapTimes(schedule_json)
+        driver_names = l_times.get_driver_names()
+        driver_positions = l_times.get_driver_positions()
+        driver_timings = l_times.get_lap_time()
+    
+        return pd.DataFrame(
+            zip(
+                driver_positions,
+                driver_names,
+                driver_timings,
+            ),
+            columns=[
+                "POS",
+                "Driver",
+                "Lap Time",
+            ],
+        )
 
 
 def pit_stops(year: int, race_round: int, stop_number: int = 0):
     """Returns the pit stops for a specific race in a season"""
-    if int == 0:
-        json_data = _get_json_content_from_url(
-            f"https://ergast.com/api/f1/{year}/{race_round}/pitstops.json"
-        )
+    if year < 2012 and year > 2022:
+        raise ValueError("Only years between 2012 and 2022 are considered as valid value for year")
     else:
-        json_data = _get_json_content_from_url(
-            f"https://ergast.com/api/f1/{year}/{race_round}/pitstops/{stop_number}.json"
-        )
-    stops_json = json_data["MRData"]["RaceTable"]["Races"][0]["PitStops"]
-    p_stops = PitStops(stops_json)
-    driver_names = p_stops.get_driver_names()
-    stop_number = p_stops.get_stop_numbers()
-    lap_number = p_stops.get_lap_numbers()
-    race_time = p_stops.get_times()
-    stop_duration = p_stops.get_durations()
+        if int == 0:
+            json_data = _get_json_content_from_url(
+                f"https://ergast.com/api/f1/{year}/{race_round}/pitstops.json"
+            )
+        else:
+            json_data = _get_json_content_from_url(
+                f"https://ergast.com/api/f1/{year}/{race_round}/pitstops/{stop_number}.json"
+            )
+        stops_json = json_data["MRData"]["RaceTable"]["Races"][0]["PitStops"]
+        p_stops = PitStops(stops_json)
+        driver_names = p_stops.get_driver_names()
+        stop_number = p_stops.get_stop_numbers()
+        lap_number = p_stops.get_lap_numbers()
+        race_time = p_stops.get_times()
+        stop_duration = p_stops.get_durations()
 
-    return pd.DataFrame(
-        zip(driver_names, stop_number, lap_number, race_time, stop_duration),
-        columns=["Driver", "Stop", "Lap", "Time", "Duration"],
-    )
+        return pd.DataFrame(
+            zip(driver_names, stop_number, lap_number, race_time, stop_duration),
+            columns=["Driver", "Stop", "Lap", "Time", "Duration"],
+        )
 
 
 def finishing_status(year: int, race_round: int = 0):
     """Returns the finishing status for a year with a optional parameter of round"""
-    if race_round == 0:
-        json_data = _get_json_content_from_url(f"https://ergast.com/api/f1/{year}/status.json")
+    if year < 1950 and year > 2022:
+        raise ValueError("Only years between 1950 and 2022 are considered as valid value for year")
     else:
-        json_data = _get_json_content_from_url(
-            f"https://ergast.com/api/f1/{year}/{race_round}/status.json"
+        if race_round == 0:
+            json_data = _get_json_content_from_url(f"https://ergast.com/api/f1/{year}/status.json")
+        else:
+            json_data = _get_json_content_from_url(
+                f"https://ergast.com/api/f1/{year}/{race_round}/status.json"
+            )
+        f_status = FinishingStatus(json_data["MRData"]["StatusTable"]["Status"])
+        status_id = f_status.get_status_id()
+        status_info = f_status.get_status()
+        status_count = f_status.get_status_count()
+    
+        return pd.DataFrame(
+            zip(status_id, status_info, status_count), columns=["StatusId", "Status", "Count"]
         )
-    f_status = FinishingStatus(json_data["MRData"]["StatusTable"]["Status"])
-    status_id = f_status.get_status_id()
-    status_info = f_status.get_status()
-    status_count = f_status.get_status_count()
-
-    return pd.DataFrame(
-        zip(status_id, status_info, status_count), columns=["StatusId", "Status", "Count"]
-    )
 
 
 def sprint_results(year: int, race_round: int):
     """Returns the sprint qualifying results for a year and round"""
-    json_data = _get_json_content_from_url(
-        f"http://ergast.com/api/f1/{year}/{race_round}/sprint.json"
-    )
-    if len(json_data["MRData"]["RaceTable"]["Races"]) == 0 :
-        raise ValueError("No Sprint Race found for this Grand Prix")
-    s_results = SprintResults(json_data["MRData"]["RaceTable"]["Races"][0]["SprintResults"])
-    driver_pos = s_results.get_driver_pos()
-    driver_name = s_results.get_driver_name()
-    driver_team = s_results.get_driver_team()
-    driver_status = s_results.get_driver_status()
-    driver_number = s_results.get_driver_number()
-    driver_laps = s_results.get_laps()
-    driver_grid = s_results.get_driver_grid()
-    driver_time = s_results.get_driver_time()
-    driver_points = s_results.get_driver_points()
-
-    return pd.DataFrame(
-        zip(
-            driver_pos, driver_name, driver_number, driver_team, driver_laps, driver_grid,
-            driver_status, driver_time, driver_points
-        ),
-        columns=[
-            "Position", "Name", "Driver Number", "Constructor", "Laps", "Grid",
-            "Status", "Time", "Points"
-        ]
-    )
+    if year < 1950 and year > 2022:
+        raise ValueError("Only years between 1950 and 2022 are considered as valid value for year")
+    else:
+        json_data = _get_json_content_from_url(
+            f"http://ergast.com/api/f1/{year}/{race_round}/sprint.json"
+        )
+        if len(json_data["MRData"]["RaceTable"]["Races"]) == 0 :
+            raise ValueError("No Sprint Race found for this Grand Prix")
+        s_results = SprintResults(json_data["MRData"]["RaceTable"]["Races"][0]["SprintResults"])
+        driver_pos = s_results.get_driver_pos()
+        driver_name = s_results.get_driver_name()
+        driver_team = s_results.get_driver_team()
+        driver_status = s_results.get_driver_status()
+        driver_number = s_results.get_driver_number()
+        driver_laps = s_results.get_laps()
+        driver_grid = s_results.get_driver_grid()
+        driver_time = s_results.get_driver_time()
+        driver_points = s_results.get_driver_points()
+    
+        return pd.DataFrame(
+            zip(
+                driver_pos, driver_name, driver_number, driver_team, driver_laps, driver_grid,
+                driver_status, driver_time, driver_points
+            ),
+            columns=[
+                "Position", "Name", "Driver Number", "Constructor", "Laps", "Grid",
+                "Status", "Time", "Points"
+            ]
+        )
 
 
 def get_constructors(year: int = None):
     """Returns a list of constructors for a specified year"""
     if year is None:
         url = "https://ergast.com/api/f1/constructors.json?limit=230"
+    elif year < 1950 or year > 2022:
+        raise ValueError("Only years between 1950 and 2022 are considered as valid value for year")
     else:
         url = f"http://ergast.com/api/f1/{year}/constructors.json"
 
@@ -267,43 +296,48 @@ def get_constructors(year: int = None):
 
 def qualifying_results(year: int, race_round: int):
     """Returns the driver name , driver position, driver number, constructor name , the 3 Q times"""
-    json_data = _get_json_content_from_url(
-        f"https://ergast.com/api/f1/{year}/{race_round}/qualifying.json"
-    )
-    schedule_json = json_data["MRData"]["RaceTable"]["Races"][0]["QualifyingResults"]
-    r_obj= QualifyingResults(schedule_json)
-    driver_positions=r_obj.get_positions()
-    driver_names=r_obj.get_names()
-    driver_numbers=r_obj.get_driver_numbers()
-    constructor_names=r_obj.get_constructors()
-    q1_times=r_obj.get_q1_times()
-    q2_times=r_obj.get_q2_times()
-    q3_times=r_obj.get_q3_times()
-    return pd.DataFrame(
-        zip(
-            driver_positions,
-            driver_names,
-            driver_numbers,
-            constructor_names,
-            q1_times,
-            q2_times,
-            q3_times
-        ),
-        columns=[
-            "Position",
-            "DriverName",
-            "DriverNumber",
-            "Constructor",
-            "Q1",
-            "Q2",
-            "Q3"
-        ],
-    )
+    if year < 1950 and year > 2022:
+        raise ValueError("Only years between 1950 and 2022 are considered as valid value for year")
+    else:
+        json_data = _get_json_content_from_url(
+            f"https://ergast.com/api/f1/{year}/{race_round}/qualifying.json"
+        )
+        schedule_json = json_data["MRData"]["RaceTable"]["Races"][0]["QualifyingResults"]
+        r_obj= QualifyingResults(schedule_json)
+        driver_positions=r_obj.get_positions()
+        driver_names=r_obj.get_names()
+        driver_numbers=r_obj.get_driver_numbers()
+        constructor_names=r_obj.get_constructors()
+        q1_times=r_obj.get_q1_times()
+        q2_times=r_obj.get_q2_times()
+        q3_times=r_obj.get_q3_times()
+        return pd.DataFrame(
+            zip(
+                driver_positions,
+                driver_names,
+                driver_numbers,
+                constructor_names,
+                q1_times,
+                q2_times,
+                q3_times
+            ),
+            columns=[
+                "Position",
+                "DriverName",
+                "DriverNumber",
+                "Constructor",
+                "Q1",
+                "Q2",
+                "Q3"
+            ],
+        )
 
 def get_circuits(year:int=None):
     """Returns the circuit name, circuit locality and circuit country"""
     if year is None:
         json_data = _get_json_content_from_url("http://ergast.com/api/f1/circuits.json?limit=76")
+    elif year < 1950 or year > 2022:
+        raise ValueError("Only years between 1950 and 2022 are considered as valid value for year")
     else:
         json_data = _get_json_content_from_url(f"https://ergast.com/api/f1/{year}/circuits.json")
     schedule_json = json_data["MRData"]["CircuitTable"]["Circuits"]

--- a/f1pystats/f1pystats.py
+++ b/f1pystats/f1pystats.py
@@ -27,7 +27,7 @@ from .constructor_info import ConstructorInfo
 
 def get_drivers(year: int, round_num: int = None):
     """Returns a list of drivers for a specified year"""
-    if year < 1950 and year > 2022:
+    if year < 1950 or year > 2022:
         raise ValueError("Only years between 1950 and 2022 are considered as valid value for year")
     else:
         if round_num is None:
@@ -52,7 +52,7 @@ def get_drivers(year: int, round_num: int = None):
 
 def driver_standings(year: int):
     """Returns the driver standings for a specified year"""
-    if year < 1950 and year > 2022:
+    if year < 1950 or year > 2022:
         raise ValueError("Only years between 1950 and 2022 are considered as valid value for year")
     else:
         json_data = _get_json_content_from_url(f"https://ergast.com/api/f1/{year}/driverStandings.json")
@@ -73,7 +73,7 @@ def driver_standings(year: int):
 
 def constructor_standings(year: int):
     """Returns the constructor standings for a specified year"""
-    if year < 1950 and year > 2022:
+    if year < 1950 or year > 2022:
         raise ValueError("Only years between 1950 and 2022 are considered as valid value for year")
     else:
         json_data = _get_json_content_from_url(
@@ -97,7 +97,7 @@ def constructor_standings(year: int):
 
 def race_winners(year: int):
     """Returns the race winners in a specified year"""
-    if year < 1950 and year > 2022:
+    if year < 1950 or year > 2022:
         raise ValueError("Only years between 1950 and 2022 are considered as valid value for year")
     else:
         json_data = _get_json_content_from_url(f"https://ergast.com/api/f1/{year}/results/1.json")
@@ -127,7 +127,7 @@ def race_winners(year: int):
 
 def race_table(year: int):
     """Returns the race schedule for a specified year"""
-    if year < 1950 and year > 2022:
+    if year < 1950 or year > 2022:
         raise ValueError("Only years between 1950 and 2022 are considered as valid value for year")
     else:
         json_data = _get_json_content_from_url(f"https://ergast.com/api/f1/{year}.json")
@@ -165,7 +165,7 @@ def race_table(year: int):
 
 def lap_times(year: int, race_round: int, lap_number: int):
     """Returns the lap times for a specified year, race round and lap number"""
-    if year < 1950 and year > 2022:
+    if year < 1950 or year > 2022:
         raise ValueError("Only years between 1950 and 2022 are considered as valid value for year")
     else:
         json_data = _get_json_content_from_url(
@@ -193,7 +193,7 @@ def lap_times(year: int, race_round: int, lap_number: int):
 
 def pit_stops(year: int, race_round: int, stop_number: int = 0):
     """Returns the pit stops for a specific race in a season"""
-    if year < 2012 and year > 2022:
+    if year < 2012 or year > 2022:
         raise ValueError("Only years between 2012 and 2022 are considered as valid value for year")
     else:
         if int == 0:
@@ -220,7 +220,7 @@ def pit_stops(year: int, race_round: int, stop_number: int = 0):
 
 def finishing_status(year: int, race_round: int = 0):
     """Returns the finishing status for a year with a optional parameter of round"""
-    if year < 1950 and year > 2022:
+    if year < 1950 or year > 2022:
         raise ValueError("Only years between 1950 and 2022 are considered as valid value for year")
     else:
         if race_round == 0:
@@ -241,7 +241,7 @@ def finishing_status(year: int, race_round: int = 0):
 
 def sprint_results(year: int, race_round: int):
     """Returns the sprint qualifying results for a year and round"""
-    if year < 1950 and year > 2022:
+    if year < 1950 or year > 2022:
         raise ValueError("Only years between 1950 and 2022 are considered as valid value for year")
     else:
         json_data = _get_json_content_from_url(
@@ -296,7 +296,7 @@ def get_constructors(year: int = None):
 
 def qualifying_results(year: int, race_round: int):
     """Returns the driver name , driver position, driver number, constructor name , the 3 Q times"""
-    if year < 1950 and year > 2022:
+    if year < 1950 or year > 2022:
         raise ValueError("Only years between 1950 and 2022 are considered as valid value for year")
     else:
         json_data = _get_json_content_from_url(

--- a/f1pystats/f1pystats.py
+++ b/f1pystats/f1pystats.py
@@ -337,8 +337,9 @@ def get_circuits(year:int=None):
         json_data = _get_json_content_from_url("http://ergast.com/api/f1/circuits.json?limit=76")
     elif year < 1950 or year > 2022:
         raise ValueError("Only years between 1950 and 2022 are considered as valid value for year")
-
-    json_data = _get_json_content_from_url(f"https://ergast.com/api/f1/{year}/circuits.json")
+    else:
+        json_data = _get_json_content_from_url(f"https://ergast.com/api/f1/{year}/circuits.json")
+    
     schedule_json = json_data["MRData"]["CircuitTable"]["Circuits"]
     rr_obj=RaceCircuits(schedule_json)
     circuit_name=rr_obj.get_circuit_name()


### PR DESCRIPTION
## Description
Added bugfix to only process the years between 1950 and 2022, (and 2012 to 2022 for pit-stop data).

## Related Issue(s)
Fixes #68 

## User-facing Changes
<!-- Describe any user-facing changes here. -->
Users will no longer be greeted with a vague error when entering out-of-range year values into functions.