### PR TITLE
Fix #94

### DIFF
--- a/f1pystats/f1pystats.py
+++ b/f1pystats/f1pystats.py
@@ -31,24 +31,33 @@ def _get_json_content_from_url(url, *args, timeout: int = 15, **kwargs):
 
 
 def _get_sec(time_str):
-        """Get seconds from time string"""
-        s = 0
-        num_str = ''
+        """Returns seconds from time string"""
+        sec = 0
+        num = 0
+        dplace = 0
         for c in time_str:
-            if '0' <= c and c <= '9':
-                num_str += c
-            elif c == ':':
-                s += int(num_str)
-                s *= 60
-                num_str = ''
-            elif c == '.':
-                s += int(num_str)
-                num_str = '.'
-        if num_str[0] == '.':
-            s += float(num_str)
+            if dplace == 0:
+                if '0' <= c and c <= '9':
+                    num = num * 10 + ( ord(c) - ord('0') )
+                elif c == ':':
+                    sec += num
+                    sec *= 60
+                    num = 0
+                elif c == '.':
+                    sec += num
+                    num = 0
+                    dplace = -1
+            else:
+                if '0' <= c and c <= '9':
+                    num = num * 10 + ( ord(c) - ord('0') )
+                    dplace -= 1
+
+        if dplace == 0:
+            sec += num
         else:
-            s += int(num_str)
-        return s
+            sec += num * pow(10, dplace + 1)
+
+        return sec
 
 
 # Requesting the season list and get the last one to initialize CURR_YEAR

--- a/f1pystats/f1pystats.py
+++ b/f1pystats/f1pystats.py
@@ -30,7 +30,7 @@ def _get_json_content_from_url(url, *args, timeout: int = 15, **kwargs):
     return requests.get(url, *args, timeout=timeout, **kwargs).json()
 
 
-def _get_sec(time_str):
+def get_sec(time_str):
     """Returns seconds from time string"""
     sec = 0
     num = 0
@@ -265,7 +265,7 @@ def pit_stops(year: int, race_round: int, stop_number: int = 0, fastest: bool = 
     stops_json = json_data["MRData"]["RaceTable"]["Races"][0]["PitStops"]
 
     if fastest:
-        ftime = min((i["duration"] for i in stops_json), key=_get_sec)
+        ftime = min((i["duration"] for i in stops_json), key=get_sec)
         stops_json = [i for i in stops_json
                             if i["duration"] == ftime]
 

--- a/f1pystats/f1pystats.py
+++ b/f1pystats/f1pystats.py
@@ -37,7 +37,7 @@ def _get_sec(time_str):
     dplace = 0
     for char in time_str:
         if dplace == 0:
-            if '0' <= char and char <= '9':
+            if '0' <= char <= '9':
                 num *= 10
                 num += ord(char) - ord('0')
             elif char == ':':
@@ -49,7 +49,7 @@ def _get_sec(time_str):
                 num = 0
                 dplace = -1
         else:
-            if '0' <= char and char <= '9':
+            if '0' <= char <= '9':
                 num *= 10
                 num += ord(char) - ord('0')
                 dplace -= 1

--- a/f1pystats/f1pystats.py
+++ b/f1pystats/f1pystats.py
@@ -30,6 +30,27 @@ def _get_json_content_from_url(url, *args, timeout: int = 15, **kwargs):
     return requests.get(url, *args, timeout=timeout, **kwargs).json()
 
 
+def _get_sec(time_str):
+        """Get seconds from time string"""
+        s = 0
+        num_str = ''
+        for c in time_str:
+            if '0' <= c and c <= '9':
+                num_str += c
+            elif c == ':':
+                s += int(num_str)
+                s *= 60
+                num_str = ''
+            elif c == '.':
+                s += int(num_str)
+                num_str = '.'
+        if num_str[0] == '.':
+            s += float(num_str)
+        else:
+            s += int(num_str)
+        return s
+
+
 # Requesting the season list and get the last one to initialize CURR_YEAR
 CURR_YEAR = int(
     _get_json_content_from_url(

--- a/f1pystats/f1pystats.py
+++ b/f1pystats/f1pystats.py
@@ -35,23 +35,23 @@ def _get_sec(time_str):
     sec = 0
     num = 0
     dplace = 0
-    for ch in time_str:
+    for char in time_str:
         if dplace == 0:
-            if '0' <= ch and ch <= '9':
+            if '0' <= char and char <= '9':
                 num *= 10
-                num += ord(ch) - ord('0')
-            elif ch == ':':
+                num += ord(char) - ord('0')
+            elif char == ':':
                 sec += num
                 sec *= 60
                 num = 0
-            elif ch == '.':
+            elif char == '.':
                 sec += num
                 num = 0
                 dplace = -1
         else:
-            if '0' <= ch and ch <= '9':
+            if '0' <= char and char <= '9':
                 num *= 10
-                num += ord(ch) - ord('0')
+                num += ord(char) - ord('0')
                 dplace -= 1
 
     if dplace == 0:

--- a/f1pystats/f1pystats.py
+++ b/f1pystats/f1pystats.py
@@ -31,33 +31,35 @@ def _get_json_content_from_url(url, *args, timeout: int = 15, **kwargs):
 
 
 def _get_sec(time_str):
-        """Returns seconds from time string"""
-        sec = 0
-        num = 0
-        dplace = 0
-        for c in time_str:
-            if dplace == 0:
-                if '0' <= c and c <= '9':
-                    num = num * 10 + ( ord(c) - ord('0') )
-                elif c == ':':
-                    sec += num
-                    sec *= 60
-                    num = 0
-                elif c == '.':
-                    sec += num
-                    num = 0
-                    dplace = -1
-            else:
-                if '0' <= c and c <= '9':
-                    num = num * 10 + ( ord(c) - ord('0') )
-                    dplace -= 1
-
+    """Returns seconds from time string"""
+    sec = 0
+    num = 0
+    dplace = 0
+    for ch in time_str:
         if dplace == 0:
-            sec += num
+            if '0' <= ch and ch <= '9':
+                num *= 10
+                num += ord(ch) - ord('0')
+            elif ch == ':':
+                sec += num
+                sec *= 60
+                num = 0
+            elif ch == '.':
+                sec += num
+                num = 0
+                dplace = -1
         else:
-            sec += num * pow(10, dplace + 1)
+            if '0' <= ch and ch <= '9':
+                num *= 10
+                num += ord(ch) - ord('0')
+                dplace -= 1
 
-        return sec
+    if dplace == 0:
+        sec += num
+    else:
+        sec += num * pow(10, dplace + 1)
+
+    return sec
 
 
 # Requesting the season list and get the last one to initialize CURR_YEAR

--- a/f1pystats/f1pystats.py
+++ b/f1pystats/f1pystats.py
@@ -266,8 +266,7 @@ def pit_stops(year: int, race_round: int, stop_number: int = 0, fastest: bool = 
 
     if fastest:
         ftime = min((i["duration"] for i in stops_json), key=get_sec)
-        stops_json = [i for i in stops_json
-                            if i["duration"] == ftime]
+        stops_json = [i for i in stops_json if i["duration"] == ftime]
 
     p_stops = PitStops(stops_json)
     driver_names = p_stops.get_driver_names()

--- a/f1pystats/f1pystats.py
+++ b/f1pystats/f1pystats.py
@@ -263,8 +263,9 @@ def pit_stops(year: int, race_round: int, stop_number: int = 0, fastest: bool = 
     stops_json = json_data["MRData"]["RaceTable"]["Races"][0]["PitStops"]
 
     if fastest:
-        stops_json = [i for i in stops_json if i["duration"]
-                      == min(i["duration"] for i in stops_json)]
+        ftime = min((i["duration"] for i in stops_json), key=_get_sec)
+        stops_json = [i for i in stops_json
+                            if i["duration"] == ftime]
 
     p_stops = PitStops(stops_json)
     driver_names = p_stops.get_driver_names()

--- a/tests/package_tests/test_util.py
+++ b/tests/package_tests/test_util.py
@@ -13,13 +13,3 @@ class TestUtil(BaseTestClass):
         assert self.fp._get_sec("1:23:45.67") == 5025.67 # Full format
         assert self.fp._get_sec("")           == 0       # non input        
         assert self.fp._get_sec(".")          == 0       # naked decimal point
-
-    def test_sprint_results(self):
-        """Tests the results returned from sprint_results()"""
-        results = self.fp.sprint_results(2021, 10)
-        assert self.get_vals(results) == self.get_data("sprint_2021_10.json")
-
-    def test_bad_sprint_value(self):
-        """Tests the sprint_results() function if bad values are given"""
-        with self.pytest.raises(ValueError):
-            self.fp.sprint_results(2021, 9)

--- a/tests/package_tests/test_util.py
+++ b/tests/package_tests/test_util.py
@@ -8,8 +8,9 @@ class TestUtil(BaseTestClass):
 
     def test_get_sec(self):
         """Test seconds returned from _get_sec"""
-        assert self.fp._get_sec(     "58.79") == 58.79   # Niki Lauda 1974 R9 Q
-        assert self.fp._get_sec(      "1"   ) == 1       # Minimum format
-        assert self.fp._get_sec("1:23:45.67") == 5025.67 # Full format
-        assert self.fp._get_sec("")           == 0       # non input        
-        assert self.fp._get_sec(".")          == 0       # naked decimal point
+        assert self.fp._get_sec(     "58.79")  == 58.79  # Niki Lauda 1974 R9 Q
+        assert self.fp._get_sec(      "1"   )  == 1      # Minimum format
+        want = (1 * 3600) + (23 * 60) + 45.678
+        assert self.fp._get_sec("1:23:45.678") == want   # Full format
+        assert self.fp._get_sec("")            == 0      # non input        
+        assert self.fp._get_sec(".")           == 0      # naked decimal point

--- a/tests/package_tests/test_util.py
+++ b/tests/package_tests/test_util.py
@@ -8,9 +8,9 @@ class TestUtil(BaseTestClass):
 
     def test_get_sec(self):
         """Test seconds returned from _get_sec"""
-        assert self.fp._get_sec(     "58.79")  == 58.79  # Niki Lauda 1974 R9 Q
-        assert self.fp._get_sec(      "1"   )  == 1      # Minimum format
+        assert self.fp.get_sec(     "58.79")  == 58.79  # Niki Lauda 1974 R9 Q
+        assert self.fp.get_sec(      "1"   )  == 1      # Minimum format
         want = (1 * 3600) + (23 * 60) + 45.678
-        assert self.fp._get_sec("1:23:45.678") == want   # Full format
-        assert self.fp._get_sec("")            == 0      # non input
-        assert self.fp._get_sec(".")           == 0      # naked decimal point
+        assert self.fp.get_sec("1:23:45.678") == want   # Full format
+        assert self.fp.get_sec("")            == 0      # non input
+        assert self.fp.get_sec(".")           == 0      # naked decimal point

--- a/tests/package_tests/test_util.py
+++ b/tests/package_tests/test_util.py
@@ -12,5 +12,5 @@ class TestUtil(BaseTestClass):
         assert self.fp._get_sec(      "1"   )  == 1      # Minimum format
         want = (1 * 3600) + (23 * 60) + 45.678
         assert self.fp._get_sec("1:23:45.678") == want   # Full format
-        assert self.fp._get_sec("")            == 0      # non input        
+        assert self.fp._get_sec("")            == 0      # non input
         assert self.fp._get_sec(".")           == 0      # naked decimal point

--- a/tests/package_tests/test_util.py
+++ b/tests/package_tests/test_util.py
@@ -8,11 +8,11 @@ class TestUtil(BaseTestClass):
 
     def test_get_sec(self):
         """Test seconds returned from _get_sec"""
-        assert self.fp._get_sec(     "58.79") == 58.79
-        assert self.fp._get_sec(   "0:58.79") == 58.79
-        assert self.fp._get_sec("1:23:45")    == 5025
-        # Not support for an decimal point at the end.
-        #assert LapTimes._get_sec("1:23:45.")  == 5025
+        assert self.fp._get_sec(     "58.79") == 58.79   # Niki Lauda 1974 R9 Q
+        assert self.fp._get_sec(      "1"   ) == 1       # Minimum format
+        assert self.fp._get_sec("1:23:45.67") == 5025.67 # Full format
+        assert self.fp._get_sec("")           == 0       # non input        
+        assert self.fp._get_sec(".")          == 0       # naked decimal point
 
     def test_sprint_results(self):
         """Tests the results returned from sprint_results()"""

--- a/tests/package_tests/test_util.py
+++ b/tests/package_tests/test_util.py
@@ -8,9 +8,9 @@ class TestUtil(BaseTestClass):
 
     def test_get_sec(self):
         """Test seconds returned from _get_sec"""
-        assert self.fp.get_sec(     "58.79")  == 58.79  # Niki Lauda 1974 R9 Q
-        assert self.fp.get_sec(      "1"   )  == 1      # Minimum format
+        assert self.fp.get_sec("58.79") == 58.79       # Niki Lauda 1974 R9 Q
+        assert self.fp.get_sec("1") == 1               # Minimum format
         want = (1 * 3600) + (23 * 60) + 45.678
-        assert self.fp.get_sec("1:23:45.678") == want   # Full format
-        assert self.fp.get_sec("")            == 0      # non input
-        assert self.fp.get_sec(".")           == 0      # naked decimal point
+        assert self.fp.get_sec("1:23:45.678") == want  # Full format
+        assert self.fp.get_sec("") == 0                # non input
+        assert self.fp.get_sec(".") == 0               # naked decimal point

--- a/tests/package_tests/test_util.py
+++ b/tests/package_tests/test_util.py
@@ -1,0 +1,25 @@
+"""This module contains tests for the utility functions"""
+
+from .base_test_class import BaseTestClass
+
+
+class TestUtil(BaseTestClass):
+    """Tests for the utility functions"""
+
+    def test_get_sec(self):
+        """Test seconds returned from _get_sec"""
+        assert self.fp._get_sec(     "58.79") == 58.79
+        assert self.fp._get_sec(   "0:58.79") == 58.79
+        assert self.fp._get_sec("1:23:45")    == 5025
+        # Not support for an decimal point at the end.
+        #assert LapTimes._get_sec("1:23:45.")  == 5025
+
+    def test_sprint_results(self):
+        """Tests the results returned from sprint_results()"""
+        results = self.fp.sprint_results(2021, 10)
+        assert self.get_vals(results) == self.get_data("sprint_2021_10.json")
+
+    def test_bad_sprint_value(self):
+        """Tests the sprint_results() function if bad values are given"""
+        with self.pytest.raises(ValueError):
+            self.fp.sprint_results(2021, 9)


### PR DESCRIPTION
## Description

The cause was that duration time was compared in lexicographic order.

### Changes.

1. Defined the function _get_sec to convert from time expressed as a string to seconds.
2. Specified a comparison function for the key keyword argument key of the min function.



## Related Issue(s)
<!-- Please note any issue numbers this pull request addresses/resolves (There should be at least one)-->
Fixes #94 

## User-facing Changes
None.

## Screenshots (If necessary)
None.