### PR TITLE
Fix #97

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -50,3 +50,6 @@ jobs:
         poetry run pytest --cov-report lcov --cov
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
+      with:
+        files: coverage.lcov
+        fail_ci_if_error: true

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -47,6 +47,6 @@ jobs:
         poetry run flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        poetry run pytest --cov
+        poetry run pytest --cov-report lcov --cov
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3


### PR DESCRIPTION
## Description

### Why CodeCov have been not updated.

1. PR #86 (unexpectedly) changed where the coverage report file is generated.
2. codecov/codecov-action now fails to find the coverage report file.

### How to Fix

1. Add `files` option to make `codecov/codecov-action` able to find the coverage report file.

## Related Issue(s)
* PR #86
* Issue #97 
