### PR TITLE
Update setup-python@v4

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install and configure Poetry

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
+coverage.lcov
 
 # Translations
 *.mo


### PR DESCRIPTION
## Description
2 changes.

1. Update setup-python@v4 according to the following warning statement.
```
Warning: The `set-output` command is deprecated and will be disabled soon
```
2. Make git ignore coverage.lcov

## Related Issue(s)
None.
## User-facing Changes
None.
## Screenshots (If necessary)
None.