### PR TITLE
Fix module entry in mypy.ini

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,4 @@
 [mypy]
 
-[nox.*,pytest,pytest_mock,_pytest.*,pandas.*]
+[mypy-pandas]
 ignore_missing_imports = True


### PR DESCRIPTION
## Description
Fix the following missing imports error.

```
f1pystats/f1pystats.py:3: error: Skipping analyzing "pandas": module is installed, but missing library stubs or py.typed marker  [import]
f1pystats/f1pystats.py:3: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
```

## Related Issue(s)
* #113.

## User-facing Changes
None.

## Screenshots (If necessary)
None.
