### PR TITLE
Fix #113 no overload

### DIFF
--- a/f1pystats/f1pystats.py
+++ b/f1pystats/f1pystats.py
@@ -266,13 +266,13 @@ def pit_stops(year: int, race_round: int, stop_number: int = 0, fastest: bool = 
 
     p_stops = PitStops(stops_json)
     driver_names = p_stops.get_driver_names()
-    stop_number = p_stops.get_stop_numbers()
+    stop_numbers = p_stops.get_stop_numbers()
     lap_number = p_stops.get_lap_numbers()
     race_time = p_stops.get_times()
     stop_duration = p_stops.get_durations()
 
     return pd.DataFrame(
-        zip(driver_names, stop_number, lap_number, race_time, stop_duration),
+        zip(driver_names, stop_numbers, lap_number, race_time, stop_duration),
         columns=["Driver", "Stop", "Lap", "Time", "Duration"],
     )
 

--- a/f1pystats/f1pystats.py
+++ b/f1pystats/f1pystats.py
@@ -267,12 +267,12 @@ def pit_stops(year: int, race_round: int, stop_number: int = 0, fastest: bool = 
     p_stops = PitStops(stops_json)
     driver_names = p_stops.get_driver_names()
     stop_numbers = p_stops.get_stop_numbers()
-    lap_number = p_stops.get_lap_numbers()
-    race_time = p_stops.get_times()
-    stop_duration = p_stops.get_durations()
+    lap_numbers = p_stops.get_lap_numbers()
+    race_times = p_stops.get_times()
+    stop_durations = p_stops.get_durations()
 
     return pd.DataFrame(
-        zip(driver_names, stop_numbers, lap_number, race_time, stop_duration),
+        zip(driver_names, stop_numbers, lap_numbers, race_times, stop_durations),
         columns=["Driver", "Stop", "Lap", "Time", "Duration"],
     )
 


### PR DESCRIPTION
## Description

A variable `stop_number` was reassigned at line 269. Now, Assigned it to a new separate variable `stop_numbers` (with a trailing **s**) and change the call to the zip function on line 275 to also give the variable.

The original variable `stop_number` is described as type int with type hint at line 246.
The use of that variable, which was supposed to be of type int, in the call to zip was reported as an error.

Also, `lap_number`, `race_time`, and `stop_duration` were changed to match the naming convention in `stop_numbers`.

## Related Issue(s)
Fixes #113 