### PR TITLE
Fix building the API Docs

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -38,9 +38,11 @@ jobs:
         with:
           path: .venv
           key: venv-${{ hashFiles('**/poetry.lock') }}
-      - name: Install dependencies
+      - name: Install dependencies(with cache)
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: poetry install --no-interaction --no-root --all-extras
+      - name: Install our projects
+        run: poetry install --only-root
       - name: Build
         run: poetry run sphinx-build -M html docs docs/_build
       - name: Setup Pages


### PR DESCRIPTION
## Description

The following error occurred when generating the API doc
```
WARNING: autodoc: failed to import module 'constructor_info' from module 'f1pystats' ...
No module named 'f1pystats'
```

To resolve this issue, Added the following command in the workflow.
```
poetry install --root-only
```

## Related Issue(s)
* #120 