### PR TITLE
Update noxfile.py for lint and code_coverage session

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,11 @@ You can follow the instructions in the [README](https://github.com/alec-kr/F1PyS
 By Default, Nox deletes and recreates virtualenvs every time it is run. If -R option is
 specified, reuse virtualenvs and skip re-installation of packages.
 
+linting check:
+```
+$ poetry run nox -s lint
+```
+
 Static type check:
 ```
 $ poetry run nox -s mypy 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,11 +7,14 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 """Sphinx configuration."""
 
-import toml
+
 import os
 from typing import List
 
-metadata = toml.load(os.path.join(os.path.dirname(__file__), '..', 'pyproject.toml'))["tool"]["poetry"]
+import toml
+
+pyproject_path = os.path.join(os.path.dirname(__file__), '..', 'pyproject.toml')
+metadata = toml.load(pyproject_path)["tool"]["poetry"]
 
 project = "F1PyStats"
 author = ",".join(metadata["authors"])
@@ -27,13 +30,12 @@ extensions = [
     "sphinx_autodoc_typehints",
 ]
 
-#templates_path = ['_templates']
-exclude_patterns = [] # type: List[str]
-
+# templates_path = ['_templates']
+exclude_patterns = []  # type: List[str]
 
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
 html_theme = 'furo'
-#html_static_path = ['_static']
+# html_static_path = ['_static']

--- a/noxfile.py
+++ b/noxfile.py
@@ -44,7 +44,11 @@ def tests(session: Session) -> None:
 @session(python=python_versions[-1])
 def code_coverage(session: Session) -> None:
     """Run package coverage."""
-    pass
+    session.install("pytest",
+                    "pytest-cov",
+                    "requests",
+                    "pandas")
+    session.run("pytest", "--cov", "--cov-report=lcov")
 
 
 @session(python=python_versions[-1])

--- a/noxfile.py
+++ b/noxfile.py
@@ -5,6 +5,7 @@ from nox_poetry import session
 locations = "f1pystats", "tests", "noxfile.py", "docs/conf.py"
 python_versions = ['3.9', '3.10', '3.11']
 
+
 @session(python=python_versions[-1])
 def lint(session: Session) -> None:
     """Runs linting for the package."""

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,11 +1,12 @@
 """Nox sessoins."""
+from nox_poetry import Session
 from nox_poetry import session
 
 locations = "f1pystats", "tests", "noxfile.py", "docs/conf.py"
 
 
 @session(python=['3.8'])
-def lint(session) -> None:
+def lint(session: Session) -> None:
     """Runs linting for the package."""
     args = session.posargs or locations
     session.install("flake8",
@@ -19,7 +20,7 @@ def lint(session) -> None:
 
 
 @session
-def mypy(session) -> None:
+def mypy(session: Session) -> None:
     """Runs type checking the package."""
     args = session.posargs or locations
     session.install("mypy",
@@ -32,7 +33,7 @@ def mypy(session) -> None:
 
 
 @session(python=['3.9', '3.10', '3.11'])
-def tests(session) -> None:
+def tests(session: Session) -> None:
     """Run all tests."""
     session.install("pytest",
                     "requests",
@@ -41,13 +42,13 @@ def tests(session) -> None:
 
 
 @session(python='3.8')
-def code_coverage(session) -> None:
+def code_coverage(session: Session) -> None:
     """Run package coverage."""
     pass
 
 
 @session
-def docs(session) -> None:
+def docs(session: Session) -> None:
     """Build the documentation."""
     session.install("sphinx",
                     "sphinx-autodoc-typehints",

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,3 +1,4 @@
+"""Nox sessoins."""
 from nox_poetry import session
 
 locations = "f1pystats", "tests", "noxfile.py", "docs/conf.py"
@@ -24,9 +25,9 @@ def mypy(session) -> None:
     session.install("mypy",
                     "types-requests",
                     "numpy",
-                    "pytest",                    
+                    "pytest",
                     "nox_poetry",
-                    "types-toml")    
+                    "types-toml")
     session.run("mypy", *args)
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -3,9 +3,9 @@ from nox_poetry import Session
 from nox_poetry import session
 
 locations = "f1pystats", "tests", "noxfile.py", "docs/conf.py"
+python_versions = ['3.9', '3.10', '3.11']
 
-
-@session(python=['3.8'])
+@session(python=python_versions[-1])
 def lint(session: Session) -> None:
     """Runs linting for the package."""
     args = session.posargs or locations
@@ -19,7 +19,7 @@ def lint(session: Session) -> None:
     session.run("flake8", *args)
 
 
-@session
+@session(python=python_versions)
 def mypy(session: Session) -> None:
     """Runs type checking the package."""
     args = session.posargs or locations
@@ -32,7 +32,7 @@ def mypy(session: Session) -> None:
     session.run("mypy", *args)
 
 
-@session(python=['3.9', '3.10', '3.11'])
+@session(python=python_versions)
 def tests(session: Session) -> None:
     """Run all tests."""
     session.install("pytest",
@@ -41,13 +41,13 @@ def tests(session: Session) -> None:
     session.run("pytest")
 
 
-@session(python='3.8')
+@session(python=python_versions[-1])
 def code_coverage(session: Session) -> None:
     """Run package coverage."""
     pass
 
 
-@session
+@session(python=python_versions[-1])
 def docs(session: Session) -> None:
     """Build the documentation."""
     session.install("sphinx",

--- a/poetry.lock
+++ b/poetry.lock
@@ -1097,14 +1097,14 @@ testutils = ["gitpython (>3)"]
 
 [[package]]
 name = "pytest"
-version = "7.3.0"
+version = "7.3.1"
 description = "pytest: simple powerful testing with Python"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pytest-7.3.0-py3-none-any.whl", hash = "sha256:933051fa1bfbd38a21e73c3960cebdad4cf59483ddba7696c48509727e17f201"},
-    {file = "pytest-7.3.0.tar.gz", hash = "sha256:58ecc27ebf0ea643ebfdf7fb1249335da761a00c9f955bcd922349bcb68ee57d"},
+    {file = "pytest-7.3.1-py3-none-any.whl", hash = "sha256:3799fa815351fea3a5e96ac7e503a96fa51cc9942c3753cda7651b93c1cfa362"},
+    {file = "pytest-7.3.1.tar.gz", hash = "sha256:434afafd78b1d78ed0addf160ad2b77a30d35d4bdf8af234fe621919d9ed15e3"},
 ]
 
 [package.dependencies]


### PR DESCRIPTION
## Description

### CONTRIBUTING.md
1. Add linting check

### noxfile.py
1. Fix linting error
2. Add type hints
3. Update the python version for `lint` session
4. Change to running on all versions for `mypy` session
5. Implement `code_coverage` session
6. Specify the python version of the `docs` session explicitly

### docs/conf.py
1. Fix linting error

### poetry.lock
1. Update pytest to 7.3.1

## Related Issue(s)
#128 