### PR TITLE
Removed the extra close method.

### DIFF
--- a/tests/module_tests/test_constructor_info.py
+++ b/tests/module_tests/test_constructor_info.py
@@ -12,7 +12,6 @@ class TestConstructorInfo:
     with open("tests/test_data/module_data/sample_constructor_info_2010.json",
               encoding="utf-8") as f:
         data = json.load(f)
-        f.close()
 
     constructor = ConstructorInfo(data)
 

--- a/tests/module_tests/test_constructor_results.py
+++ b/tests/module_tests/test_constructor_results.py
@@ -11,7 +11,6 @@ class TestConstructorResults:
     data = ""
     with open("tests/test_data/module_data/top_3_constructors_2008.json", encoding="utf-8") as f:
         data = json.load(f)
-        f.close()
 
     c_res = ConstructorResults(data)
 

--- a/tests/module_tests/test_driver_info.py
+++ b/tests/module_tests/test_driver_info.py
@@ -12,7 +12,6 @@ class TestDriverInfo:
 
     with open("tests/test_data/module_data/sample_drivers_info_2000.json", encoding="utf-8") as f:
         data = json.load(f)
-        f.close()
 
     driver = DriverInfo(data)
 

--- a/tests/module_tests/test_driver_results.py
+++ b/tests/module_tests/test_driver_results.py
@@ -11,7 +11,6 @@ class TestDriverResults:
     data = ""
     with open("tests/test_data/module_data/top_3_drivers_2008.json", encoding="utf-8") as f:
         data = json.load(f)
-        f.close()
 
     d_res = DriverResults(data)
 

--- a/tests/module_tests/test_finishing_status.py
+++ b/tests/module_tests/test_finishing_status.py
@@ -11,7 +11,6 @@ class TestFinishingStatus:
     data = ""
     with open("tests/test_data/module_data/top_3_status_2010.json", encoding='utf-8') as f:
         data = json.load(f)
-        f.close()
 
     f_status = FinishingStatus(data)
 

--- a/tests/module_tests/test_lap_times.py
+++ b/tests/module_tests/test_lap_times.py
@@ -11,7 +11,6 @@ class TestLapTimes:
     data = ""
     with open("tests/test_data/module_data/sample_lap_times_2008.json", encoding="utf-8") as f:
         data = json.load(f)
-        f.close()
 
     l_times = LapTimes(data)
 

--- a/tests/module_tests/test_pitstops.py
+++ b/tests/module_tests/test_pitstops.py
@@ -13,7 +13,6 @@ class TestPitStops:
               encoding="utf-8") as f:
 
         data = json.load(f)
-        f.close()
 
     p_stops = PitStops(data)
 

--- a/tests/module_tests/test_qualifying_results.py
+++ b/tests/module_tests/test_qualifying_results.py
@@ -12,7 +12,6 @@ class TestQualifyingResults:
     with open("tests/test_data/module_data/first_3_qualifying_results_2022.json",
               encoding="utf-8") as f:
         data = json.load(f)
-        f.close()
 
     r_obj = QualifyingResults(data)
 

--- a/tests/module_tests/test_race_circuits.py
+++ b/tests/module_tests/test_race_circuits.py
@@ -10,7 +10,6 @@ class TestRaceCircuits:
     data = ""
     with open("tests/test_data/module_data/first_3_race_circuits.json", encoding="utf-8") as f:
         data = json.load(f)
-        f.close()
     c_obj = RaceCircuits(data)
 
     def test_get_circuit_name(self):

--- a/tests/module_tests/test_race_schedule.py
+++ b/tests/module_tests/test_race_schedule.py
@@ -11,7 +11,6 @@ class TestRaceSchedule:
     data = ""
     with open("tests/test_data/module_data/first_3_races_2008.json", encoding="utf-8") as f:
         data = json.load(f)
-        f.close()
 
     r_sched = RaceSchedule(data)
 

--- a/tests/module_tests/test_race_winners.py
+++ b/tests/module_tests/test_race_winners.py
@@ -11,7 +11,6 @@ class TestRaceWinners:
     data = ""
     with open("tests/test_data/module_data/first_3_winners_2008.json", encoding="utf-8") as f:
         data = json.load(f)
-        f.close()
 
     r_win = RaceWinners(data)
 

--- a/tests/module_tests/test_sprint_results.py
+++ b/tests/module_tests/test_sprint_results.py
@@ -11,7 +11,6 @@ class TestSprintResults:
     data = ""
     with open("tests/test_data/module_data/top_3_sprint_2022_11.json", encoding='utf-8') as f:
         data = json.load(f)
-        f.close()
 
     s_result = SprintResults(data)
 

--- a/tests/package_tests/base_test_class.py
+++ b/tests/package_tests/base_test_class.py
@@ -18,6 +18,5 @@ class BaseTestClass:
         data = ""
         with open(f"tests/test_data/api_data/{file_name}", encoding="utf-8") as data_file:
             data = self.json.load(data_file)
-            data_file.close()
 
         return data


### PR DESCRIPTION
## Description

Removed the extra close method.

I felt that this might make the code a bit cleaner.
Note that the close method called the second time has no effect.

Cited for reference: 
> It is good practice to use the [with](https://docs.python.org/3/reference/compound_stmts.html#with) keyword when dealing with file objects. The advantage is that the file is properly **closed** after its suite finishes, even if an exception is raised at some point.
-- Python Software Foundation. The Python Tutorial, Section [7.2: Reading and Writing Files](https://docs.python.org/3/tutorial/inputoutput.html#reading-and-writing-files)

## Related Issue(s)
None.

## User-facing Changes
None.

## Screenshots (If necessary)
None.